### PR TITLE
Update createSinglePackage.sh

### DIFF
--- a/cli/scripts/bin/createSinglePackage.sh
+++ b/cli/scripts/bin/createSinglePackage.sh
@@ -90,8 +90,9 @@ then
     mv "${WORKSPACE}"/${componentIds[$g]}.xml "${packageFolder}/${folderFullPath}" 
  done
   
-  # Create a violations report using sonarqube rules	
-	bin/xpathRulesChecker.sh baseFolder="${packageFolder}" > "${packageFolder}/ViolationsReport_${saveComponentId}.html"
+  # Create a violations report using sonarqube rules
+  # 17 July 21 - @jgould-sonos - Added "source" resolving issue
+	source bin/xpathRulesChecker.sh baseFolder="${packageFolder}" > "${packageFolder}/ViolationsReport_${saveComponentId}.html"
 
 fi
 


### PR DESCRIPTION
Added "source" argument to source bin/xpathRulesChecker.sh baseFolder="${packageFolder}" > "${packageFolder}/ViolationsReport_${saveComponentId}.html"
in CreateSinglePackage.sh.

Currently when creating an package if exporting to local disk using the "extractComponentXmlFolder" argument an error is shown to the CLI because the xpathRulesChecker is not sources. Tested with Resolution